### PR TITLE
Moved require target at bin/phpmig. because the composer is moving autoload files.

### DIFF
--- a/bin/phpmig
+++ b/bin/phpmig
@@ -14,10 +14,10 @@ if (!defined('PHPMIG_VERSION')) {
     define('PHPMIG_VERSION', 'dev');
 }
 
-if (is_file(__DIR__ . '/../vendor/.composer/autoload.php')) {
-    require_once __DIR__ . '/../vendor/.composer/autoload.php';
-} else if (is_file(__DIR__ . '/../../../.composer/autoload.php')) {
-    require_once __DIR__ . '/../../../.composer/autoload.php';
+if (is_file(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else if (is_file(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
 } else if (is_dir(__DIR__ . '/../src/Phpmig')) {
     require_once __DIR__ . "/../src/Phpmig/autoload.php.dist";
 } else {


### PR DESCRIPTION
Hi, I'm using Phpmig with composer.

composer moved autoload files from vendor/.composer/\* to vendor/ .

So, want to be modifying the source to use it too.

Please read more.
- Break: Moved autoload files from vendor/.composer/\* to vendor/ (via google groups)
  
  https://groups.google.com/d/topic/composer-dev/fWIs3KocwoA/discussion
- Move autoload.php out of .composer directory
  
  https://github.com/composer/composer/issues/497
