### PR TITLE
Add require target . case without bin-dir (config) property into composer.json.

### DIFF
--- a/bin/phpmig
+++ b/bin/phpmig
@@ -18,6 +18,8 @@ if (is_file(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../vendor/autoload.php';
 } else if (is_file(__DIR__ . '/../../../autoload.php')) {
     require_once __DIR__ . '/../../../autoload.php';
+} else if (is_file(__DIR__ . '/../autoload.php')) {
+    require_once __DIR__ . '/../autoload.php';
 } else if (is_dir(__DIR__ . '/../src/Phpmig')) {
     require_once __DIR__ . "/../src/Phpmig/autoload.php.dist";
 } else {


### PR DESCRIPTION
When developer written composer.json without bin-dir (config) property,
bin/phpmig cannot be found autoload file.

ex.) composer.json

<pre>
{
        "require": {
            "php": ">=5.3.1",
            "davedevelopment/phpmig": "*"
        }
}
</pre>


By default, 'phpmig/bin' symbolic link is put "{root_dir}/vendor/bin",
and composer autoload dir is "{root_dir}/vendor/autoload.php".

Even if they have not been described in the configuration file, I hope to can be found.
