### PR TITLE
Fix for rollback using Zend_Db-adapter

### DIFF
--- a/src/Phpmig/Adapter/Zend/Db.php
+++ b/src/Phpmig/Adapter/Zend/Db.php
@@ -95,9 +95,9 @@ class Db implements AdapterInterface
      */
     public function down(Migration $migration)
     {
-        $this->adapter->delete($this->tableName, array(
-            'version' => $migration->getVersion(),
-        ));
+        $this->adapter->delete($this->tableName,
+            $this->adapter->quoteInto('version = ?', $migration->getVersion())
+        );
 
         return $this;
     }


### PR DESCRIPTION
Previously on rollback all existing migration-entries were deleted from the table.

Fixes:
- https://github.com/davedevelopment/phpmig/issues/19
