### PR TITLE
Support ClassName include '_'

### DIFF
--- a/src/Phpmig/Console/Command/GenerateCommand.php
+++ b/src/Phpmig/Console/Command/GenerateCommand.php
@@ -65,6 +65,9 @@ EOT
         $path = realpath($path);
 
         $className = $input->getArgument('name');
+
+        $className = str_replace('_', ' ', $className);
+        $className = str_replace(' ', '', $className);        
         $basename  = date('YmdHis') . '_' . $className . '.php';
 
         $path = $path . DIRECTORY_SEPARATOR . $basename;


### PR DESCRIPTION
``` php
./bin/phpmig generate Class_A ./migrations
#show +f ./migrations/[]_Class_A.php

#[]_Class_A.php
class Class_A extends Migration
{
//...
}

#somecode
            $class = preg_replace('/^[0-9]+_/', '', basename($path));
            $class = str_replace('_', ' ', $class);
            $class = ucwords($class);
            $class = str_replace(' ', '', $class);

#oops  Could not find class "ClassA"
```
