### PR TITLE
Adding InvalidArgumentException to namespace

### DIFF
--- a/src/Phpmig/Pimple/Pimple.php
+++ b/src/Phpmig/Pimple/Pimple.php
@@ -2,6 +2,8 @@
 
 namespace Phpmig\Pimple;
 
+use InvalidArgumentException;
+
 /*
  * This file is part of Pimple.
  *


### PR DESCRIPTION
Fixes Phpmig\Pimple\InvalidArgumentException class not found error.
