### PR TITLE
Fixed a php notice when calling getDialogHelper.

### DIFF
--- a/src/Phpmig/Migration/Migration.php
+++ b/src/Phpmig/Migration/Migration.php
@@ -42,6 +42,11 @@ class Migration
     protected $output = null;
 
     /**
+     * @var DialogHelper
+     */
+    protected $dialogHelper = null;
+
+    /**
      * Constructor
      *
      * @param int $version
@@ -67,7 +72,7 @@ class Migration
      *
      * @return void
      */
-    public function up() 
+    public function up()
     {
         return;
     }
@@ -149,7 +154,7 @@ class Migration
     /**
      * Set Output
      *
-     * @param OutputInterface $output 
+     * @param OutputInterface $output
      * @return Migrator
      */
     public function setOutput(OutputInterface $output)
@@ -168,7 +173,7 @@ class Migration
     public function ask($question, $default = null)
     {
         return $this->getDialogHelper()->ask($this->getOutput(), $question, $default);
-    } 
+    }
 
     /**
      * Ask for confirmation
@@ -180,7 +185,7 @@ class Migration
     public function confirm($question, $default = true)
     {
         return $this->getDialogHelper()->askConfirmation($this->getOutput(), $question, $default);
-    } 
+    }
 
     /**
      * Get something from the container


### PR DESCRIPTION
Fixes the following notice.

```
PHP Notice:  Undefined property: Deploy::$dialogHelper in xxx/vendor/davedevelopment/phpmig/src/Phpmig/Migration/Migration.php on line 204
```

Where "Deploy" is my Migration Name
