### PR TITLE
Fixed Warning in case of no migrations present

### DIFF
--- a/src/Phpmig/Console/Command/MigrateCommand.php
+++ b/src/Phpmig/Console/Command/MigrateCommand.php
@@ -73,7 +73,13 @@ EOT
                 return;
             }
         } else {
-            $version = max(array_merge($versions, array_keys($migrations)));
+            $versionNumbers = array_merge($versions, array_keys($migrations));
+
+            if (empty($versionNumbers)) {
+                return;
+            }
+
+            $version = max($versionNumbers);
         }
 
         $direction = $version > $current ? 'up' : 'down';


### PR DESCRIPTION
If there are no versions and no migrations present, the old code would trigger the following warning

```
$ bin/phpmig migrate
PHP Warning:  max(): Array must contain at least one element in /srv/www/vhosts/multiez.dev/vendor/davedevelopment/phpmig/src/Phpmig/Console/Command/MigrateCommand.php on line 76

Warning: max(): Array must contain at least one element in /srv/www/vhosts/multiez.dev/vendor/davedevelopment/phpmig/src/Phpmig/Console/Command/MigrateCommand.php on line 76
```

One could argue that the command should throw an exception in such this case. I'm not opinionated about this and I wanted to stay compatible with the way the command reacts on [non-existent migrations](https://github.com/davedevelopment/phpmig/blob/master/src/Phpmig/Console/Command/MigrateCommand.php#L73).
