### PR TITLE
Migration does not include a __toString()

### DIFF
--- a/src/Phpmig/Console/Command/AbstractCommand.php
+++ b/src/Phpmig/Console/Command/AbstractCommand.php
@@ -186,7 +186,7 @@ abstract class AbstractCommand extends Command
             $version = $matches[0];
 
             if (isset($versions[$version])) {
-                throw new \InvalidArgumentException(sprintf('Duplicate migration, "%s" has the same version as "%s"', $path, $versions[$version]));
+                throw new \InvalidArgumentException(sprintf('Duplicate migration, "%s" has the same version as "%s"', $path, $versions[$version]->getName()));
             }
 
             $migrationName = preg_replace('/^[0-9]+_/', '', basename($path));


### PR DESCRIPTION
The Migration class that all migrations extend does not include a `__toString()` method so the name of the class must be obtained via it's `getName()` method.
