### PR TITLE
Fix Doctrine Adapter (syntax error on PostgreSQL)

### DIFF
--- a/src/Phpmig/Adapter/Doctrine/DBAL.php
+++ b/src/Phpmig/Adapter/Doctrine/DBAL.php
@@ -57,7 +57,7 @@ class DBAL implements AdapterInterface
     public function fetchAll()
     {
         $tableName = $this->connection->quoteIdentifier($this->tableName);
-        $sql = "SELECT `version` FROM $tableName ORDER BY `version` ASC";
+        $sql = "SELECT version FROM $tableName ORDER BY version ASC";
         $all = $this->connection->fetchAll($sql);
         return array_map(function($v) {return $v['version'];}, $all);
     }


### PR DESCRIPTION
"`version`"  is not supported on PostgreSQL.
