### PR TITLE
Update example with PDO error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ $container = new Pimple();
 
 $container['db'] = $container->share(function() {
     $dbh = new PDO('mysql:dbname=testdb;host=127.0.0.1','username','passwd');
- 	$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
- 	return $dbh;
+    $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $dbh;
 });
 
 $container['phpmig.adapter'] = $container->share(function() use ($container) {


### PR DESCRIPTION
Hi I propose to add these two lines into the README file that enables the error reporting in the PDO class. We need to specify this because by default no exception will be raised on query error. Let me know if you find appropriate this request, 

Igor.
