### PR TITLE
Updated Sql adapter to support SQLite database

### DIFF
--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -189,6 +189,7 @@ class Sql implements AdapterInterface
                         'createSchema' => "CREATE table {$this->quotedTableName()} (`version` NOT NULL);",
 
                     );
+                break;
 
             case 'mysql':
             case 'pgsql':
@@ -206,6 +207,7 @@ class Sql implements AdapterInterface
                         'createSchema' => "CREATE TABLE {$this->quotedTableName()} (`version` VARCHAR(255) NOT NULL);",
 
                     );
+                break;
         }
 
         // is the type listed in the queries array? if not, thrown an exception


### PR DESCRIPTION
I found that the stock queries in the SQL adapter are not valid SQL for SQLite, so I rewrote some of the code in the SQL adapter. I implemented a switch statement to decide which queries to use, based on the PDO driver in use.

Check out the __get method at the end of the Adapter.PDO/Sql.php file to see the details.
