### PR TITLE
Add support for PostgreSQL in Adapter\PDO\Sql

### DIFF
--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -162,8 +162,23 @@ class Sql implements AdapterInterface
                     );
                 break;
 
-            case 'mysql':
             case 'pgsql':
+                $queries = array(
+
+                        'fetchAll'     => "SELECT \"version\" FROM \"{$this->tableName}\" ORDER BY \"version\" ASC",
+
+                        'up'           => "INSERT INTO \"{$this->tableName}\" VALUES (:version)",
+
+                        'down'         => "DELETE FROM \"{$this->tableName}\" WHERE \"version\" = :version",
+
+                        'hasSchema'    => "SELECT \"tablename\" FROM \"pg_tables\"",
+
+                        'createSchema' => "CREATE TABLE \"{$this->tableName}\" (\"version\" VARCHAR(255) NOT NULL)",
+
+                    );
+                break;
+
+            case 'mysql':
             default:
                 $queries = array(
 


### PR DESCRIPTION
The PostgreSQL support of Adapter\PDO\Sql is incomplete.

PostgreSQL is obviously a SQL database, but it has the different syntax from MySQL:
- Identifiers can be quoted by `"`(doublequote), not by ```(backquote)
- `INSERT INTO table SET column = value` is not suppoerted.
- `SHOW TABLES` is not supported.
- The view `pg_tables` has the info of each table.
- The column `tablename` in `pg_tables` has the name of each table.

This PR adds the PostgreSQL specific codes.
