### PR TITLE
Simplified custom migration templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,40 @@ Customising the migration template
 -----------------------------------
 
 You can change the default migration template by providing the path to a file 
-in the `phpmig.migrations_template_path` config value. The migration is parsed 
-using the `sprintf` function, so the class name should be set to `%s` to 
-ensure it gets replaced: 
+in the `phpmig.migrations_template_path` config value. If the template has a 
+`.php` extension it is included and parsed as PHP, and the `$className` variable 
+is replaced: 
+
+```php
+<?= "<?php ";?>
+
+use Phpmig\Migration\Migration;
+
+class <?= $className ?> extends Migration
+{
+    $someValue = <?= $this->container['value'] ?>; 
+
+    /**
+     * Do the migration
+     */
+    public function up()
+    {
+        $container = $this->getContainer();
+    }
+
+    /**
+     * Undo the migration
+     */
+    public function down()
+    {
+        $container = $this->getContainer();
+    }
+}
+```
+
+If it uses any other extension (e.g., `.stub` or `.tmpl`) it's parsed using the 
+`sprintf` function, so the class name should be set to `%s` to ensure it gets 
+replaced: 
 
 ```php
 <?php

--- a/src/Phpmig/Console/Command/GenerateCommand.php
+++ b/src/Phpmig/Console/Command/GenerateCommand.php
@@ -98,14 +98,21 @@ EOT
                 ));
             }
 
-            $contents = file_get_contents($migrationsTemplatePath);
+            if (preg_match('/\.php$/', $migrationsTemplatePath)) {
+                ob_start();
+                include($migrationsTemplatePath);
+                $contents = ob_get_clean();
+            } else {
+                $contents = file_get_contents($migrationsTemplatePath);
+                $contents = sprintf($contents, $className);
+            }
         } else {
             $contents = <<<PHP
 <?php
 
 use Phpmig\Migration\Migration;
 
-class %s extends Migration
+class $className extends Migration
 {
     /**
      * Do the migration
@@ -126,8 +133,6 @@ class %s extends Migration
 
 PHP;
         }
-
-        $contents = sprintf($contents, $className);
 
         if (false === file_put_contents($path, $contents)) {
             throw new \RuntimeException(sprintf(


### PR DESCRIPTION
I was adding a custom migration template to a project the other day and I noticed that because the template gets included, obviously it also gets parsed, so I ended up with this monstrosity of a template to get things working: 

``` php
<?php
echo <<<PHP
<?php
use Phpmig\Migration\Migration;

class $className extends Migration
{
        /**
         * Do the migration.
         */
        public function up()
        {
            \$container = \$this->getContainer();
        }

        /**
         * Undo the migration.
         */
        public function down()
        {
            \$container = \$this->getContainer();
        }
}

PHP;
?>
```

I've submitted a pull request that changes the way the custom template is imported to use `file_get_contents()` and `sprintf` so that templates become much simpler to write: 

``` php
<?php
use Phpmig\Migration\Migration;

class %s extends Migration
{
        /**
        * Do the migration.
        */
        public function up()
        {
            $container = $this->getContainer();
        }

        /**
         * Undo the migration.
        */
        public function down()
        {
            $container = $this->getContainer();
        }
}

```

I've also added a bit of documentation to explain how to use a custom migration template.

I'd appreciate any comments on this change. Thanks.
