### PR TITLE
Added in built in support for Illuminate\Database's default fetch mode

### DIFF
--- a/src/Phpmig/Adapter/Illuminate/Database.php
+++ b/src/Phpmig/Adapter/Illuminate/Database.php
@@ -5,8 +5,10 @@
  */
 namespace Phpmig\Adapter\Illuminate;
 
+use PDO;
 use \Phpmig\Migration\Migration,
     \Phpmig\Adapter\AdapterInterface;
+use RuntimeException;
 
 /**
  * @author Andrew Smith http://github.com/silentworks
@@ -36,13 +38,27 @@ class Database implements AdapterInterface
      */
     public function fetchAll()
     {
+        $fetchMode = $this->adapter->connection()
+            ->getFetchMode();
+
         $all = $this->adapter->connection()
             ->table($this->tableName)
             ->orderBy('version')
             ->get();
 
-        return array_map(function($v) {
-            return $v['version'];
+        return array_map(function($v) use($fetchMode) {
+
+            switch ($fetchMode) {
+
+                case PDO::FETCH_OBJ:
+                    return $v->version;
+
+                case PDO::FETCH_ASSOC:
+                    return $v['version'];
+
+                default:
+                    throw new RuntimeException("The PDO::FETCH_* constant {$fetchMode} is not supported");
+            }
         }, $all);
     }
 


### PR DESCRIPTION
When using Illuminate\Database out of the box the fetch mode is set to `PDO::FETCH_OBJ` instead of `PDO::FETCH_ASSOC`.  Also throws exception when given unknown type so that solution can be easily found.