### PR TITLE
Eloquent ORM Example documentation added

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,48 @@ $container['phpmig.migrations_path'] = function() {
 return $container;
 ```
 
+Example with Eloquent ORM 5.1
+------------------
+```php
+<?php
+
+use \Phpmig\Adapter;
+use \Phpmig\Pimple\Pimple,
+    \Illuminate\Database\Capsule\Manager as Capsule;
+
+$container = new Pimple();
+
+$container['config'] = [
+    'driver'    => 'xxx',
+    'host'      => 'xxx',
+    'database'  => 'xxx',
+    'username'  => 'xxx',
+    'password'  => 'x',
+    'charset'   => 'xxx',
+    'collation' => 'xxx',
+    'prefix'    => '',
+];
+
+$container['db'] = $container->share(function() use ($container) {
+    $capsule = new Capsule();
+    $capsule->addConnection($container['config']);
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+
+   return $capsule;
+});
+
+$container['phpmig.adapter'] = $container->share(function() use ($container) {
+    return new Adapter\Illuminate\Database($container['db'], 'migrations');
+});
+$container['phpmig.migrations_path'] = function() {
+    return __DIR__ . DIRECTORY_SEPARATOR . 'migrations';
+};
+
+return $container;
+```
+
+
 Writing Migrations
 ------------------
 


### PR DESCRIPTION
Because #83 was merged in favor of #82 , an example in README file was not merged which was in #82 . This pull request solely aims to merge it to the readme file. I was looking for an example and saw in the closed PR, so wanted to make a new one for this.

The author of this example was @varakh , so all credits goes to him directly.