### PR TITLE
Bugfix for running phpmig outside of cli when migrations table does not already exist.

### DIFF
--- a/src/Phpmig/Api/PhpmigApplication.php
+++ b/src/Phpmig/Api/PhpmigApplication.php
@@ -58,6 +58,13 @@ class PhpmigApplication
      */
     public function up($version = null)
     {
+        $adapter = $this->container['phpmig.apdater'];
+
+        if (!$adapter->hasSchema()) {
+
+            $adapter->createSchema();
+        }
+
         foreach ($this->getMigrations($this->getVersion(), $version) as $migration) {
             $this->container['phpmig.migrator']->up($migration);
         }


### PR DESCRIPTION
When using phpmig outside of the cli the migrations table needed to exist or an error was thrown saying that the migrations table does not exist.  This fix checks if the migrations table does not exist and creates it if needed.