### PR TITLE
Bugfix for running phpmig outside of cli when migrations table does not already exist.

### DIFF
--- a/src/Phpmig/Api/PhpmigApplication.php
+++ b/src/Phpmig/Api/PhpmigApplication.php
@@ -6,6 +6,7 @@
 namespace Phpmig\Api;
 
 use Phpmig\Migration;
+use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -58,8 +59,15 @@ class PhpmigApplication
      */
     public function up($version = null)
     {
-        if (array_key_exists('phpmig.adapter', $this->container) && ! $this->container['phpmig.adapter']->hasSchema()) {
-            
+        $adapter = ! empty($this->container['phpmig.adapter']) ? $this->container['phpmig.adapter'] : null;
+
+        if ($adapter == null) {
+
+            throw new RuntimeException("The container must contain a phpmig.adapter key!");
+        }
+
+        if (!$adapter->hasSchema()) {
+
             $this->container['phpmig.adapter']->createSchema();
         }
 

--- a/src/Phpmig/Api/PhpmigApplication.php
+++ b/src/Phpmig/Api/PhpmigApplication.php
@@ -58,6 +58,11 @@ class PhpmigApplication
      */
     public function up($version = null)
     {
+        if (array_key_exists('phpmig.adapter', $this->container) && ! $this->container['phpmig.adapter']->hasSchema()) {
+            
+            $this->container['phpmig.adapter']->createSchema();
+        }
+
         foreach ($this->getMigrations($this->getVersion(), $version) as $migration) {
             $this->container['phpmig.migrator']->up($migration);
         }

--- a/tests/Phpmig/Api/PhpmigApplicationTest.php
+++ b/tests/Phpmig/Api/PhpmigApplicationTest.php
@@ -52,6 +52,10 @@ class PhpmigApplicationTest extends \PHPUnit_Framework_TestCase
     public function testUp()
     {
         $adapter = $this->getAdapter(array($this->prev_version, $this->current_version));
+        $adapter->expects($this->once())
+                ->method('hasSchema')
+                ->will($this->returnValue(false));
+
         $migrations = $this->getMigrations();
         $this->createTestMigrations($migrations);
         
@@ -59,10 +63,10 @@ class PhpmigApplicationTest extends \PHPUnit_Framework_TestCase
         $container['phpmig.migrator'] = $this->getMigrator($adapter, $container, $this->output, 1, 0);
         
         $app = new PhpmigApplication($container, $this->output);
-        
+
         $app->up($this->next_version);
     }
-    
+
     /**
      * @covers ::down
      */


### PR DESCRIPTION
When using phpmig outside of the cli the migrations table needed to exist or an error was thrown saying that the migrations table does not exist. This fix checks if the migrations table does not exist and creates it if needed.