### PR TITLE
Add symfony v3 and up to dependency ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "2.*",
-        "symfony/yaml": "2.*",
-        "symfony/config": "2.*",
-        "symfony/class-loader": "2.*"
+        "symfony/console": "^2||^3",
+        "symfony/yaml": "^2||^3",
+        "symfony/config": "^2||^3",
+        "symfony/class-loader": "^2||^3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.*",


### PR DESCRIPTION
Trying to do composer require doesn't work when I am already depending on symfony ^3. Hope this is an ok fix.