### PR TITLE
Support for using yajra/laravel-pdo-via-oci8

### DIFF
--- a/src/Phpmig/Adapter/PDO/SqlOci.php
+++ b/src/Phpmig/Adapter/PDO/SqlOci.php
@@ -22,7 +22,7 @@ class SqlOci extends Sql {
 	public function __construct( \PDO $connection, $tableName ) {
 		parent::__construct( $connection, $tableName );
 		$driver = $this->connection->getAttribute( PDO::ATTR_DRIVER_NAME );
-		if ( ! in_array( $driver, array( 'oci' ) ) ) {
+		if ( ! in_array( $driver, array( 'oci', 'oci8' ) ) ) {
 			throw new \Exception( 'Please install OCI drivers for PDO!' );
 		}
 	}


### PR DESCRIPTION
[yajra/laravel-pdo-via-oci8](https://github.com/yajra/pdo-via-oci8) is a userspace PDO driver for oracle (that actually works).

It uses 'oci8' for ATTR_DRIVER_NAME