### PR TITLE
GenerateCommand decoupling

### DIFF
--- a/src/Phpmig/Console/Command/AbstractCommand.php
+++ b/src/Phpmig/Console/Command/AbstractCommand.php
@@ -224,7 +224,7 @@ abstract class AbstractCommand extends Command
             if ($this instanceof GenerateCommand
                 && $class == $this->migrationToClassName($input->getArgument('name'))) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Migration Class "%s" is already exists',
+                    'Migration Class "%s" already exists',
                     $class
                 ));
             }

--- a/src/Phpmig/Console/Command/AbstractCommand.php
+++ b/src/Phpmig/Console/Command/AbstractCommand.php
@@ -221,7 +221,7 @@ abstract class AbstractCommand extends Command
             }
             $class = $this->migrationToClassName($migrationName);
 
-            if ($input->getArgument('command') == 'generate'
+            if ($this instanceof GenerateCommand
                 && $class == $this->migrationToClassName($input->getArgument('name'))) {
                 throw new \InvalidArgumentException(sprintf(
                     'Migration Class "%s" is already exists',


### PR DESCRIPTION
Currently it's impossible to run the generate command outside of the console context (main application). Consider the following scenario which happened when I was making new commands with [Robo](https://github.com/Codegyre/Robo) (one of its features is that it can run Symfony Console commands):

```php
/**
 * Generates a new migration.
 */
public function phpmigNew()
{
    $migrationGeneration = $this->taskSymfonyCommand(new \Phpmig\Console\Command\GenerateCommand());

    $migrationName = $this->ask('Name of the new migration');

    if (empty($migrationName)) {
        throw new InvalidArgumentException('You must provide a name for the migration.');
    }

    $migrationGeneration->arg('name', $migrationName);

    if ($this->confirm('Is this migration unsafe?')) {
        $migrationGeneration->opt('set', 'unsafe');
    }

    $migrationGeneration->run();
}
```

If you run this on an empty migration folder it runs without issues, but otherwise you get the following exception:

```
The "command" argument does not exist.
```

This happens because in the `AbstractCommand` class the `getArgument` method is used to check which command is currently running. The command argument only gets set if the command is ran within the Symfony Console application. See `getDefaultInputDefinition` method inside the `Application` class of the Symfony Console package:

https://github.com/symfony/console/blob/master/Application.php#L870