### PR TITLE
fixed PHP Warning in Illuminate/Database adapter

### DIFF
--- a/src/Phpmig/Adapter/Illuminate/Database.php
+++ b/src/Phpmig/Adapter/Illuminate/Database.php
@@ -44,7 +44,7 @@ class Database implements AdapterInterface
         $all = $this->adapter
             ->table($this->tableName)
             ->orderBy('version')
-            ->get();
+            ->get()->toArray();
 
         return array_map(function($v) use($fetchMode) {
 


### PR DESCRIPTION
in fetchAll method array_map is called with the result of this statement:

```php
$all = $this->adapter
  ->table($this->tableName)
  ->orderBy('version')
  ->get();
```

But `get()` returns an instance of \Illuminate\Support\Collection which is not accepted by array_map. There a call to `toArray()` has to be added to convert the Collection to an array