### PR TITLE
Fixed PHP fatal error when working with Laravel Database 5.2

### DIFF
--- a/src/Phpmig/Adapter/Illuminate/Database.php
+++ b/src/Phpmig/Adapter/Illuminate/Database.php
@@ -44,7 +44,11 @@ class Database implements AdapterInterface
         $all = $this->adapter
             ->table($this->tableName)
             ->orderBy('version')
-            ->get()->toArray();
+            ->get();
+
+        if(!is_array($all)) {
+            $all = $all->toArray();
+        }
 
         return array_map(function($v) use($fetchMode) {
 


### PR DESCRIPTION
toArray() function only called when get() is not an array.