### PR TITLE
Add pdo_sqlsrv support

### DIFF
--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -146,6 +146,25 @@ class Sql implements AdapterInterface
 
         switch($this->pdoDriverName)
         {
+            case 'sqlsrv':
+                $queries = array(
+
+                        'fetchAll'     => "SELECT version FROM {$this->tableName} ORDER BY version ASC",
+
+                        'up'           => "INSERT INTO {$this->tableName} VALUES (:version)",
+
+                        'down'         => "DELETE FROM {$this->tableName} WHERE version = :version",
+
+                        'hasSchema'    => "Select Table_name as 'Table name'
+                            From Information_schema.Tables
+                            Where Table_type = 'BASE TABLE' and Objectproperty
+                            (Object_id(Table_name), 'IsMsShipped') = 0",
+
+                        'createSchema' => "CREATE table {$this->tableName} (version varchar(255) NOT NULL)",
+
+                    );
+                break;
+
             case 'sqlite':
                 $queries = array(
 


### PR DESCRIPTION
I need this function to my job.

Test result.
```console
ubuntu@ubuntu-xenial:/vagrant/sanrio_sys/web$ vendor/bin/phpmig -vvv status

 Status   Migration ID    Migration Name
-----------------------------------------
     up  20161206113249  CraeteTable1

ubuntu@ubuntu-xenial:/vagrant/sanrio_sys/web$ vendor/bin/phpmig -vvv status

 Status   Migration ID    Migration Name
-----------------------------------------
   down  20161206113249  CraeteTable1

ubuntu@ubuntu-xenial:/vagrant/web$ vendor/bin/phpmig -vvv migrate
 == 20161206113249 CraeteTable1 migrating
 == 20161206113249 CraeteTable1 migrated 0.0989s
ubuntu@ubuntu-xenial:/vagrant/web$ vendor/bin/phpmig -vvv status

 Status   Migration ID    Migration Name
-----------------------------------------
     up  20161206113249  CraeteTable1

ubuntu@ubuntu-xenial:/vagrant/web$ vendor/bin/phpmig -vvv rollback
 == 20161206113249 CraeteTable1 reverting
 == 20161206113249 CraeteTable1 reverted 0.0935s
ubuntu@ubuntu-xenial:/vagrant/web$ vendor/bin/phpmig -vvv status

 Status   Migration ID    Migration Name
-----------------------------------------
   down  20161206113249  CraeteTable1
```

Sample phpmig.php (Pimple version bumped to 3.x)

```php
<?php

# phpmig.php

use \Phpmig\Adapter;
use Pimple\Container;

$container = new Container();


$container['db'] = function() {
    $dbh = new PDO("sqlsrv:server = tcp:foo-bar-baz.database.windows.net,1433; Database = foo-install-test", "accountname", "accountpassword");
        $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
        return $dbh;
};

$container['phpmig.adapter'] = new Adapter\PDO\Sql($container['db'], 'migrations');

$container['phpmig.migrations_path'] = __DIR__ . DIRECTORY_SEPARATOR . 'migrations';
$container['phpmig.migrations_template_path'] = __DIR__ . DIRECTORY_SEPARATOR . 'phpmig_template.php';

return $container;
```

Sample migration file

```php
<?php
use Phpmig\Migration\Migration;
use Store\Migration\Helper;

class CraeteTable1 extends Migration
{
    /**
     * Do the migration
     */
    public function up()
    {

        $sql = <<<EOS
create table hogehoge (
  id int identity(1,1) not null,
  name nvarchar(1024) not null)
EOS;

        // Get PDO instance from container
        $container = $this->getContainer();
        $con = $container['db'];

        $con->beginTransaction();
        $con->exec($sql);
        $con->commit();
    }

    /**
     * Undo the migration
     */
    public function down()
    {

        $sql = <<<EOS
drop table hogehoge
EOS;

        // Get PDO instance from container
        $container = $this->getContainer();
        $con = $container['db'];

        $con->beginTransaction();
        $con->exec($sql);
        $con->commit();
    }
}
```