### PR TITLE
Add pdo_dblib support

### DIFF
--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -146,6 +146,7 @@ class Sql implements AdapterInterface
 
         switch($this->pdoDriverName)
         {
+            case 'dblib':
             case 'sqlsrv':
                 $queries = array(
 


### PR DESCRIPTION
## environment

```bash
$ php -i | grep dblib
/etc/php.d/30-pdo_dblib.ini,
PDO drivers => dblib, mysql, sqlite
pdo_dblib
```

## before

```bash
$ bin/phpmig generate Example

                                                                                                                                         
  [PDOException]                                                                                                                         
  SQLSTATE[HY000]: General error: 2812 General SQL Server error: Check messages from the SQL Server [2812] (severity 16) [SHOW TABLES;]  
```

```php
// phpmig/src/Phpmig/Adapter/PDO/Sql.php
            case 'mysql':
            default:
                $queries = array(

                        'fetchAll'     => "SELECT `version` FROM {$this->quotedTableName()} ORDER BY `version` ASC",

                        'up'           => "INSERT into {$this->quotedTableName()} set version = :version",

                        'down'         => "DELETE from {$this->quotedTableName()} where version = :version",

                        'hasSchema'    => "SHOW TABLES;",

                        'createSchema' => "CREATE TABLE {$this->quotedTableName()} (`version` VARCHAR(255) NOT NULL);",

                    );
                break;
```

## after

```bash
$ bin/phpmig generate Example
+f ./migrations/20170106114835_Example.php
```

## reference
- https://github.com/davedevelopment/phpmig/pull/119
- http://php.net/manual/en/ref.pdo-dblib.connection.php
- http://php.net/manual/en/ref.pdo-sqlsrv.connection.php
