### PR TITLE
illuminate database 5.2 and up fetchmode problem

### DIFF
--- a/src/Phpmig/Adapter/Illuminate/Database.php
+++ b/src/Phpmig/Adapter/Illuminate/Database.php
@@ -38,8 +38,8 @@ class Database implements AdapterInterface
      */
     public function fetchAll()
     {
-        $fetchMode = $this->adapter
-            ->getFetchMode();
+        $fetchMode = (method_exists($this->adapter, 'getFetchMode')) ?
+            $this->adapter->getFetchMode() : PDO::FETCH_OBJ;
 
         $all = $this->adapter
             ->table($this->tableName)


### PR DESCRIPTION
I added checking for getFetchMode method because illuminate/database v 5.2 and up throws error ` Call to undefined method Illuminate\Database\MySqlConnection::getFetchMode()`