### PR TITLE
start to providing reconnection ability

### DIFF
--- a/src/Phpmig/Adapter/AdapterInterface.php
+++ b/src/Phpmig/Adapter/AdapterInterface.php
@@ -59,6 +59,13 @@ interface AdapterInterface
      * @return AdapterInterface
      */
     public function createSchema();
+    
+    /**
+     * Is the adapter still connected?
+     * 
+     * @return bool
+     */
+    public function isConnected();
 }
 
 

--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -221,5 +221,25 @@ class Sql implements AdapterInterface
 
         return $queries[$type];
     }
+
+    /**
+     * Is the adapter still connected?
+     * 
+     * @return bool
+     */
+    public function isConnected()
+    {
+        try {
+            $this->connection->query('SELECT 1');
+        } catch (\PDOException $pdoE) {
+            if (stristr($pdoE->getMessage(), 'MySQL server has gone away') !== false) {
+                return false;
+            }
+            throw $e;
+        }
+        
+        return true;
+    }
+
 }
 

--- a/src/Phpmig/Console/Command/AbstractCommand.php
+++ b/src/Phpmig/Console/Command/AbstractCommand.php
@@ -148,7 +148,11 @@ abstract class AbstractCommand extends Command
             $adapter = $container['phpmig.sets'][$set]['adapter'];
         }
         if (isset($container['phpmig.adapter'])) {
-            $adapter = $container['phpmig.adapter'];
+            if (is_callable($container['phpmig.adapter'])) {
+                $adapter = $container['phpmig.adapter']();
+            } else {
+                $adapter = $container['phpmig.adapter'];
+            }
         }
 
         if (!($adapter instanceof AdapterInterface)) {

--- a/src/Phpmig/Migration/Migrator.php
+++ b/src/Phpmig/Migration/Migrator.php
@@ -142,6 +142,11 @@ class Migrator
      */
     public function getAdapter()
     {
+        if (!$this->adapter->isConnected()) {
+            if (is_callable($this->container['phpmig.adapter'])) {
+                $this->adapter = $this->container['phpmig.adapter']();
+            }
+        }
         return $this->adapter;
     }
 


### PR DESCRIPTION
So this is a start to the issue raised in #123 about MySQL going away from phpmig itself. I modified it so that you can provide a function to `['phpmig.adapter']` instead of the actual adapter, which will return the Adapter itself.

It's expandable so that each adapter can have it's own test to see if it's still connected or not (only wrote one for MySQL for now).