### PR TITLE
Fix Cannot pass parameter by reference in MongoAdapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 
 .project
 .settings
+.idea

--- a/src/Phpmig/Adapter/Mongo.php
+++ b/src/Phpmig/Adapter/Mongo.php
@@ -42,7 +42,7 @@ class Mongo implements AdapterInterface
     public function fetchAll()
     {
         $cursor = $this->connection->selectCollection($this->tableName)->find();
-        $versions = array(); 
+        $versions = array();
         foreach($cursor as $version) $versions[] = $version['version'];
         return $versions;
     }
@@ -55,10 +55,8 @@ class Mongo implements AdapterInterface
      */
     public function up(Migration $migration)
     {
-        
-        $this->connection->selectCollection($this->tableName)->insert(array(
-            'version' => $migration->getVersion()
-        ));
+        $document = array('version' => $migration->getVersion());
+        $this->connection->selectCollection($this->tableName)->insert($document);
 
         return $this;
     }
@@ -71,9 +69,8 @@ class Mongo implements AdapterInterface
      */
     public function down(Migration $migration)
     {
-        $this->connection->selectCollection($this->tableName)->remove(array(
-            'version' => $migration->getVersion()
-        ));
+        $document = array('version' => $migration->getVersion());
+        $this->connection->selectCollection($this->tableName)->remove($document);
 
         return $this;
     }
@@ -89,7 +86,7 @@ class Mongo implements AdapterInterface
         $tableName = $this->tableName;
         return array_filter(
             $this->connection->getCollectionNames(),
-            function( $collection ) use ($tableName) { 
+            function( $collection ) use ($tableName) {
                 return $collection === $tableName;
         });
     }
@@ -102,10 +99,10 @@ class Mongo implements AdapterInterface
      */
     public function createSchema()
     {
-        $this->connection->selectCollection($this->tableName)->ensureIndex(
-            'version',
-            array('unique' => 1)
-        );
+        $keys = 'version';
+        $options = array('unique' => 1);
+        $this->connection->selectCollection($this->tableName)->ensureIndex($keys, $options);
+
         return $this;
     }
 }


### PR DESCRIPTION
I have tried to run my migrations in phpmig using the Mongo PHP Adapter (https://github.com/alcaeus/mongo-php-adapter) because I'm using Doctrine ODM, but when I try to run the migrations the error of `Cannot pass parameter 1 by reference` appears. 
With this little fix can work either with the legacy Mongo driver and with the adapter.

This is the error trace:
```
== 20170830081759 Migration2 migrating
PHP Fatal error:  Cannot pass parameter 1 by reference in /srv/app/vendor/davedevelopment/phpmig/src/Phpmig/Adapter/Mongo.php on line 61
PHP Stack trace:
PHP   1. {main}() /srv/app/vendor/davedevelopment/phpmig/bin/phpmig:0
PHP   2. Symfony\Component\Console\Application->run() /srv/app/vendor/davedevelopment/phpmig/bin/phpmig:30
PHP   3. Symfony\Component\Console\Application->doRun() /srv/app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:130
PHP   4. Symfony\Component\Console\Application->doRunCommand() /srv/app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:228
PHP   5. Symfony\Component\Console\Command\Command->run() /srv/app/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:874
PHP   6. Phpmig\Console\Command\MigrateCommand->execute() /srv/app/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:264
PHP   7. Phpmig\Migration\Migrator->up() /srv/app/vendor/davedevelopment/phpmig/src/Phpmig/Console/Command/MigrateCommand.php:112
PHP   8. Phpmig\Migration\Migrator->run() /srv/app/vendor/davedevelopment/phpmig/src/Phpmig/Migration/Migrator.php:65
PHP   9. Phpmig\Adapter\Mongo->up() /srv/app/vendor/davedevelopment/phpmig/src/Phpmig/Migration/Migrator.php:103
```