### PR TITLE
Patch all occurences of phpmig.sets with deep level key access w/o parent

### DIFF
--- a/src/Phpmig/Console/Command/AbstractCommand.php
+++ b/src/Phpmig/Console/Command/AbstractCommand.php
@@ -173,7 +173,7 @@ abstract class AbstractCommand extends Command
         $container = $this->getContainer();
         $set = $input->getOption('set');
 
-        if (!isset($container['phpmig.migrations']) && !isset($container['phpmig.migrations_path']) && !isset($container['phpmig.sets'][$set]['migrations_path'])) {
+        if (!isset($container['phpmig.migrations']) && !isset($container['phpmig.migrations_path']) && (isset($container['phpmig.sets']) && !isset($container['phpmig.sets'][$set]['migrations_path']))) {
             throw new \RuntimeException($this->getBootstrap() . ' must return container with array at phpmig.migrations or migrations default path at phpmig.migrations_path or migrations default path at phpmig.sets');
         }
 

--- a/src/Phpmig/Console/Command/GenerateCommand.php
+++ b/src/Phpmig/Console/Command/GenerateCommand.php
@@ -60,9 +60,12 @@ EOT
             if (true === isset($this->container['phpmig.migrations_path'])) {
                 $path = $this->container['phpmig.migrations_path'];
             }
-            if (true === isset($this->container['phpmig.sets'][$set]['migrations_path'])) {
-                $path = $this->container['phpmig.sets'][$set]['migrations_path'];
-            }
+	    // do not deep link to nested keys without first testing the parent key
+	    if (true === isset($this->container['phpmig.sets'])){
+		    if (true === isset($this->container['phpmig.sets'][$set]['migrations_path'])) {
+			$path = $this->container['phpmig.sets'][$set]['migrations_path'];
+		    }
+	    }
         }
         $locator = new FileLocator(array());
         $path = $locator->locate($path, getcwd(), $first = true);
@@ -91,7 +94,7 @@ EOT
 
         $className = $this->migrationToClassName($migrationName);
 
-        if (isset($this->container['phpmig.migrations_template_path']) || isset($this->container['phpmig.sets'][$set]['migrations_template_path'])) {
+        if (isset($this->container['phpmig.migrations_template_path']) || (isset($this->container['phpmig.sets']) && isset($this->container['phpmig.sets'][$set]['migrations_template_path']))) {
             if (true === isset($this->container['phpmig.migrations_template_path'])) {
                 $migrationsTemplatePath = $this->container['phpmig.migrations_template_path'];
             } else {


### PR DESCRIPTION
Hi, 

Simple bug fixes for undefined phpmig.sets keys when accessing deeply nested keys on the pimple container. 

Seems to get things working again. Tested against Pimple v3.2.3