### PR TITLE
remove unused imports, fix Symfony 5 compatibility, update docblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 build/
 composer.lock
+.phpunit.result.cache
 
 
 .project

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --no-interaction --dev
 
-script: 
+script:
     vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "^2.0||^3.0||^4.0||^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.2",
+        "phpunit/phpunit": "^7.5||^8.5||^9.2",
         "mockery/mockery": "*@dev"
     },
     "suggest": {

--- a/src/Phpmig/Adapter/CodeIgniter/Db.php
+++ b/src/Phpmig/Adapter/CodeIgniter/Db.php
@@ -10,13 +10,22 @@ use \Phpmig\Migration\Migration,
 
 class Db implements AdapterInterface
 {
-    protected $ci = null;
+    /**
+     * @var \CI_Controller
+     */
+    protected $ci;
 
-    protected $connection = null;
+    /**
+     * @var \CI_DB_query_builder
+     */
+    protected $connection;
 
-    protected $tableName = null;
+    /**
+     * @var string
+     */
+    protected $tableName;
 
-    public function __construct($tableName)
+    public function __construct(string $tableName)
     {
         $this->ci = &get_instance();
         $this->ci->load->dbforge();
@@ -24,6 +33,9 @@ class Db implements AdapterInterface
         $this->connection = $this->ci->db;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function fetchAll()
     {
         $rows = array();
@@ -37,6 +49,9 @@ class Db implements AdapterInterface
         return $rows;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function up(Migration $migration)
     {
         $this->connection->insert(
@@ -49,6 +64,9 @@ class Db implements AdapterInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function down(Migration $migration)
     {
         $this->connection->where('version', $migration->getVersion());
@@ -57,11 +75,17 @@ class Db implements AdapterInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasSchema()
     {
         return $this->connection->table_exists($this->tableName);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function createSchema()
     {
         $fields = array(

--- a/src/Phpmig/Adapter/Doctrine/DBAL.php
+++ b/src/Phpmig/Adapter/Doctrine/DBAL.php
@@ -30,45 +30,35 @@ class DBAL implements AdapterInterface
     /**
      * @var \Doctrine\DBAL\Connection
      */
-    protected $connection = null;
+    protected $connection;
 
     /**
      * @var string
      */
-    protected $tableName = null;
+    protected $tableName;
 
-    /**
-     * Constructor
-     *
-     * @param Connection $connection
-     * @param string $tableName
-     */
-    public function __construct(Connection $connection, $tableName)
+    public function __construct(Connection $connection, string $tableName)
     {
         $this->connection = $connection;
         $this->tableName  = $tableName;
     }
 
     /**
-     * Fetch all 
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
         $tableName = $this->connection->quoteIdentifier($this->tableName);
         $sql = "SELECT version FROM $tableName ORDER BY version ASC";
         $all = $this->connection->fetchAll($sql);
+
         return array_map(function($v) {return $v['version'];}, $all);
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return DBAL
+     * {@inheritdoc}
      */
-    public function up(Migration $migration) 
+    public function up(Migration $migration)
     {
         $this->connection->insert($this->tableName, array(
             'version' => $migration->getVersion(),
@@ -78,10 +68,7 @@ class DBAL implements AdapterInterface
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return DBAL
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
@@ -93,9 +80,7 @@ class DBAL implements AdapterInterface
     }
 
     /**
-     * Is the schema ready? 
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -106,13 +91,12 @@ class DBAL implements AdapterInterface
                 return true;
             }
         }
+
         return false;
     }
 
     /**
-     * Create Schema
-     *
-     * @return DBAL
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -123,8 +107,8 @@ class DBAL implements AdapterInterface
         foreach($queries as $sql) {
             $this->connection->query($sql);
         }
+
         return $this;
     }
-
 }
 

--- a/src/Phpmig/Adapter/File/Flat.php
+++ b/src/Phpmig/Adapter/File/Flat.php
@@ -18,31 +18,24 @@ use \Phpmig\Adapter\AdapterInterface,
  */
 
 /**
- * Flat file adapter 
+ * Flat file adapter
  *
  * @author      Dave Marshall <david.marshall@atstsolutions.co.uk
  */
 class Flat implements AdapterInterface
 {
     /**
-     * @string
+     * @var string
      */
-    protected $filename = null;
+    protected $filename;
 
-    /**
-     * Construct
-     *
-     * @param string $filename
-     */
-    public function __construct($filename)
+    public function __construct(string $filename)
     {
         $this->filename = $filename;
     }
 
     /**
-     * Get all migrated version numbers
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -52,16 +45,13 @@ class Flat implements AdapterInterface
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
         $versions = $this->fetchAll();
         if (in_array($migration->getVersion(), $versions)) {
-            return;
+            return $this;
         }
 
         $versions[] = $migration->getVersion();
@@ -70,16 +60,13 @@ class Flat implements AdapterInterface
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
         $versions = $this->fetchAll();
         if (!in_array($migration->getVersion(), $versions)) {
-            return;
+            return $this;
         }
 
         unset($versions[array_search($migration->getVersion(), $versions)]);
@@ -88,9 +75,7 @@ class Flat implements AdapterInterface
     }
 
     /**
-     * Is the schema ready? 
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -98,13 +83,11 @@ class Flat implements AdapterInterface
     }
 
     /**
-     * Create Schema
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function createSchema()
     {
-        if (!is_writeable(dirname($this->filename))) {
+        if (!is_writable(dirname($this->filename))) {
             throw new \InvalidArgumentException(sprintf('The file "%s" is not writeable', $this->filename));
         }
 
@@ -117,8 +100,10 @@ class Flat implements AdapterInterface
 
     /**
      * Write to file
+     *
+     * @param array $versions
      */
-    protected function write($versions)
+    protected function write(array $versions)
     {
         if (false === file_put_contents($this->filename, implode("\n", $versions))) {
             throw new \RuntimeException(sprintf('The file "%s" could not be written to', $this->filename));

--- a/src/Phpmig/Adapter/Illuminate/Database.php
+++ b/src/Phpmig/Adapter/Illuminate/Database.php
@@ -25,16 +25,14 @@ class Database implements AdapterInterface
      */
     protected $adapter;
 
-    public function __construct($adapter, $tableName, $connectionName = '')
+    public function __construct($adapter, string $tableName, string $connectionName = '')
     {
         $this->adapter = $adapter->connection($connectionName);
         $this->tableName = $tableName;
     }
 
     /**
-     * Get all migrated version numbers
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -67,10 +65,7 @@ class Database implements AdapterInterface
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
@@ -84,10 +79,7 @@ class Database implements AdapterInterface
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
@@ -100,9 +92,7 @@ class Database implements AdapterInterface
     }
 
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -110,9 +100,7 @@ class Database implements AdapterInterface
     }
 
     /**
-     * Create Schema
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -120,5 +108,7 @@ class Database implements AdapterInterface
         $this->adapter->getSchemaBuilder()->create($this->tableName, function ($table) {
             $table->string('version');
         });
+
+        return $this;
     }
 }

--- a/src/Phpmig/Adapter/MongoDb.php
+++ b/src/Phpmig/Adapter/MongoDb.php
@@ -14,37 +14,31 @@ class MongoDb implements AdapterInterface
     /**
      * @var Database
      */
-    protected $connection = null;
+    protected $connection;
 
     /**
      * @var string
      */
-    protected $tableName = null;
+    protected $tableName;
 
-    /**
-     * @param Database $connection
-     * @param string   $tableName
-     */
-    public function __construct(Database $connection, $tableName)
+    public function __construct(Database $connection, string $tableName)
     {
         $this->connection = $connection;
         $this->tableName = $tableName;
     }
 
     /**
-     * Fetch all
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
         $cursor = $this->connection->selectCollection($this->tableName)->find(
-            array(),
-            array('$project' => array('version' => 1))
+            [],
+            ['$project' => ['version' => 1]]
         );
 
         return array_map(
-            function ($document) {
+            static function ($document) {
                 return $document['version'];
             },
             $cursor->toArray()
@@ -52,40 +46,29 @@ class MongoDb implements AdapterInterface
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
-        $document = array('version' => $migration->getVersion());
-        $this->connection->selectCollection($this->tableName)->insertOne($document);
+        $this->connection->selectCollection($this->tableName)
+            ->insertOne(['version' => $migration->getVersion()]);
 
         return $this;
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
-        $document = array('version' => $migration->getVersion());
-        $this->connection->selectCollection($this->tableName)->deleteOne($document);
+        $this->connection->selectCollection($this->tableName)
+            ->deleteOne(['version' => $migration->getVersion()]);
 
         return $this;
     }
 
-
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -98,17 +81,13 @@ class MongoDb implements AdapterInterface
         return false;
     }
 
-
     /**
-     * Create Schema
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function createSchema()
     {
-        $key = array('version' => 1);
-        $options = array('unique' => true);
-        $this->connection->selectCollection($this->tableName)->createIndex($key, $options);
+        $this->connection->selectCollection($this->tableName)
+            ->createIndex(['version' => 1], ['unique' => true]);
 
         return $this;
     }

--- a/src/Phpmig/Adapter/PDO/Sql.php
+++ b/src/Phpmig/Adapter/PDO/Sql.php
@@ -11,28 +11,25 @@ use Phpmig\Migration\Migration,
  *
  * @author Samuel Laulhau https://github.com/lalop
  */
-
 class Sql implements AdapterInterface
 {
 
     /**
      * @var \PDO
      */
-    protected $connection    = null;
+    protected $connection;
 
     /**
      * @var string
      */
-    protected $tableName     = null;
+    protected $tableName;
 
     /**
      * @var string
      */
-    protected $pdoDriverName = null;
+    protected $pdoDriverName;
 
     /**
-     * Constructor
-     *
      * @param \PDO $connection
      * @param string $tableName
      */
@@ -43,15 +40,8 @@ class Sql implements AdapterInterface
         $this->pdoDriverName = $connection->getAttribute(\PDO::ATTR_DRIVER_NAME);
     }
 
-    private function quotedTableName()
-    {
-        return "`{$this->tableName}`";
-    }
-
     /**
-     * Fetch all
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -61,10 +51,7 @@ class Sql implements AdapterInterface
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return self
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
@@ -77,10 +64,7 @@ class Sql implements AdapterInterface
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return self
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
@@ -92,11 +76,8 @@ class Sql implements AdapterInterface
         return $this;
     }
 
-
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -113,11 +94,8 @@ class Sql implements AdapterInterface
         return false;
     }
 
-
     /**
-     * Create Schema
-     *
-     * @return DBAL
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -140,79 +118,53 @@ class Sql implements AdapterInterface
      *
      * @return string
      */
-    protected function getQuery($type)
+    protected function getQuery(string $type): string
     {
-        $queries = array();
-
         switch($this->pdoDriverName)
         {
             case 'dblib':
             case 'sqlsrv':
-                $queries = array(
-
-                        'fetchAll'     => "SELECT version FROM {$this->tableName} ORDER BY version ASC",
-
-                        'up'           => "INSERT INTO {$this->tableName} VALUES (:version)",
-
-                        'down'         => "DELETE FROM {$this->tableName} WHERE version = :version",
-
-                        'hasSchema'    => "Select Table_name as 'Table name'
-                            From Information_schema.Tables
-                            Where Table_type = 'BASE TABLE' and Objectproperty
-                            (Object_id(Table_name), 'IsMsShipped') = 0",
-
-                        'createSchema' => "CREATE table {$this->tableName} (version varchar(255) NOT NULL)",
-
-                    );
+                $queries = [
+                    'fetchAll'     => "SELECT version FROM {$this->tableName} ORDER BY version ASC",
+                    'up'           => "INSERT INTO {$this->tableName} VALUES (:version)",
+                    'down'         => "DELETE FROM {$this->tableName} WHERE version = :version",
+                    'hasSchema'    => "Select Table_name as 'Table name'
+                        From Information_schema.Tables
+                        Where Table_type = 'BASE TABLE' and Objectproperty
+                        (Object_id(Table_name), 'IsMsShipped') = 0",
+                    'createSchema' => "CREATE table {$this->tableName} (version varchar(255) NOT NULL)",
+                ];
                 break;
 
             case 'sqlite':
-                $queries = array(
-
-                        'fetchAll'     => "SELECT `version` FROM {$this->quotedTableName()} ORDER BY `version` ASC",
-
-                        'up'           => "INSERT INTO {$this->quotedTableName()} VALUES (:version);",
-
-                        'down'         => "DELETE FROM {$this->quotedTableName()} WHERE version = :version",
-
-                        'hasSchema'    => "SELECT `name` FROM `sqlite_master` WHERE `type`='table';",
-
-                        'createSchema' => "CREATE table {$this->quotedTableName()} (`version` NOT NULL);",
-
-                    );
+                $queries = [
+                    'fetchAll'     => "SELECT `version` FROM {$this->quotedTableName()} ORDER BY `version` ASC",
+                    'up'           => "INSERT INTO {$this->quotedTableName()} VALUES (:version);",
+                    'down'         => "DELETE FROM {$this->quotedTableName()} WHERE version = :version",
+                    'hasSchema'    => "SELECT `name` FROM `sqlite_master` WHERE `type`='table';",
+                    'createSchema' => "CREATE table {$this->quotedTableName()} (`version` NOT NULL);",
+                ];
                 break;
 
             case 'pgsql':
-                $queries = array(
-
-                        'fetchAll'     => "SELECT \"version\" FROM \"{$this->tableName}\" ORDER BY \"version\" ASC",
-
-                        'up'           => "INSERT INTO \"{$this->tableName}\" VALUES (:version)",
-
-                        'down'         => "DELETE FROM \"{$this->tableName}\" WHERE \"version\" = :version",
-
-                        'hasSchema'    => "SELECT \"tablename\" FROM \"pg_tables\"",
-
-                        'createSchema' => "CREATE TABLE \"{$this->tableName}\" (\"version\" VARCHAR(255) NOT NULL)",
-
-                    );
+                $queries = [
+                    'fetchAll'     => "SELECT \"version\" FROM \"{$this->tableName}\" ORDER BY \"version\" ASC",
+                    'up'           => "INSERT INTO \"{$this->tableName}\" VALUES (:version)",
+                    'down'         => "DELETE FROM \"{$this->tableName}\" WHERE \"version\" = :version",
+                    'hasSchema'    => "SELECT \"tablename\" FROM \"pg_tables\"",
+                    'createSchema' => "CREATE TABLE \"{$this->tableName}\" (\"version\" VARCHAR(255) NOT NULL)",
+                ];
                 break;
 
             case 'mysql':
             default:
-                $queries = array(
-
-                        'fetchAll'     => "SELECT `version` FROM {$this->quotedTableName()} ORDER BY `version` ASC",
-
-                        'up'           => "INSERT into {$this->quotedTableName()} set version = :version",
-
-                        'down'         => "DELETE from {$this->quotedTableName()} where version = :version",
-
-                        'hasSchema'    => "SHOW TABLES;",
-
-                        'createSchema' => "CREATE TABLE {$this->quotedTableName()} (`version` VARCHAR(255) NOT NULL);",
-
-                    );
+                $queries = [
+                    'fetchAll'     => "SELECT `version` FROM {$this->quotedTableName()} ORDER BY `version` ASC",
+                    'up'           => "INSERT into {$this->quotedTableName()} set version = :version",
+                    'down'         => "DELETE from {$this->quotedTableName()} where version = :version",
+                    'hasSchema'    => "SHOW TABLES;",
+                    'createSchema' => "CREATE TABLE {$this->quotedTableName()} (`version` VARCHAR(255) NOT NULL);",
+                ];
                 break;
         }
 
@@ -220,6 +172,11 @@ class Sql implements AdapterInterface
             throw new \InvalidArgumentException("Query type not found: '{$type}'");
 
         return $queries[$type];
+    }
+
+    private function quotedTableName(): string
+    {
+        return "`{$this->tableName}`";
     }
 }
 

--- a/src/Phpmig/Adapter/PDO/SqlOci.php
+++ b/src/Phpmig/Adapter/PDO/SqlOci.php
@@ -3,7 +3,7 @@
 namespace Phpmig\Adapter\PDO;
 
 use Phpmig\Migration\Migration,
-	PDO;
+    PDO;
 
 /**
  * Simple PDO adapter to work with ORACLE database in particular.
@@ -11,96 +11,82 @@ use Phpmig\Migration\Migration,
  */
 class SqlOci extends Sql {
 
-	/**
-	 * Constructor
-	 *
-	 * @param \PDO $connection
-	 * @param string $tableName
-	 *
-	 * @throws \Exception
-	 */
-	public function __construct( \PDO $connection, $tableName ) {
-		parent::__construct( $connection, $tableName );
-		$driver = $this->connection->getAttribute( PDO::ATTR_DRIVER_NAME );
-		if ( ! in_array( $driver, array( 'oci', 'oci8' ) ) ) {
-			throw new \Exception( 'Please install OCI drivers for PDO!' );
-		}
-	}
+    /**
+     * Constructor
+     *
+     * @param \PDO $connection
+     * @param string $tableName
+     *
+     * @throws \Exception
+     */
+    public function __construct(\PDO $connection, string $tableName)
+    {
+        parent::__construct($connection, $tableName);
 
-	/**
-	 * Fetch all
-	 *
-	 * @return array
-	 */
-	public function fetchAll() {
-		$sql = 'SELECT "version" FROM "' . $this->tableName . '" ORDER BY "version" ASC';
+        $driver = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if (!in_array( $driver, ['oci', 'oci8'])) {
+            throw new \Exception('Please install OCI drivers for PDO!');
+        }
+    }
 
-		return $this->connection->query( $sql, PDO::FETCH_COLUMN, 0 )->fetchAll();
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll()
+    {
+        $sql = 'SELECT "version" FROM "' . $this->tableName . '" ORDER BY "version" ASC';
 
-	/**
-	 * Up
-	 *
-	 * @param Migration $migration
-	 *
-	 * @return self
-	 */
-	public function up( Migration $migration ) {
-		$sql         = 'INSERT INTO "' . $this->tableName . '" ("version") VALUES (:version)';
-		$this->connection->prepare( $sql )
-		                 ->execute( array(
-			                 ':version'      => $migration->getVersion()
-		                 ) );
+        return $this->connection->query( $sql, PDO::FETCH_COLUMN, 0 )->fetchAll();
+    }
 
-		return $this;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function up(Migration $migration)
+    {
+        $sql         = 'INSERT INTO "' . $this->tableName . '" ("version") VALUES (:version)';
+        $this->connection->prepare( $sql )
+                         ->execute( array(
+                             ':version'      => $migration->getVersion()
+                         ) );
 
-	/**
-	 * Down
-	 *
-	 * @param Migration $migration
-	 *
-	 * @return self
-	 */
-	public function down( Migration $migration ) {
-		$sql = 'DELETE from "' . $this->tableName . '" where "version" = :version';
-		$this->connection->prepare( $sql )
-		                 ->execute( array( ':version' => $migration->getVersion() ) );
+        return $this;
+    }
 
-		return $this;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function down(Migration $migration)
+    {
+        $sql = 'DELETE from "' . $this->tableName . '" where "version" = :version';
+        $this->connection->prepare( $sql )
+                         ->execute( array( ':version' => $migration->getVersion() ) );
 
+        return $this;
+    }
 
-	/**
-	 * Does migration table exist in db?
-	 *
-	 * @return bool
-	 */
-	public function hasSchema() {
-		$sql    = 'SELECT count(*) FROM user_tables WHERE table_name = :tableName';
-		$sth = $this->connection->prepare( $sql );
-		$sth->execute( array(
-			':tableName' => $this->tableName
-		) );
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchema()
+    {
+        $sql    = 'SELECT count(*) FROM user_tables WHERE table_name = :tableName';
+        $sth = $this->connection->prepare( $sql );
+        $sth->execute( array(
+            ':tableName' => $this->tableName
+        ) );
 
-		if ($sth->fetchColumn() == 0) {
-			return false;
-		}
+        return !($sth->fetchColumn() == 0);
+    }
 
-		return true;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function createSchema()
+    {
+        $sql = 'CREATE table "' . $this->tableName . '" ("version" VARCHAR2(4000) NOT NULL, "migrate_date" TIMESTAMP DEFAULT CURRENT_TIMESTAMP)';
+        $this->connection->exec( $sql );
 
-
-	/**
-	 * Create Schema
-	 *
-	 * @return self
-	 */
-	public function createSchema() {
-		$sql = 'CREATE table "' . $this->tableName . '" ("version" VARCHAR2(4000) NOT NULL, "migrate_date" TIMESTAMP DEFAULT CURRENT_TIMESTAMP)';
-		$this->connection->exec( $sql );
-
-		return $this;
-	}
-
+        return $this;
+    }
 }

--- a/src/Phpmig/Adapter/PDO/SqlPgsql.php
+++ b/src/Phpmig/Adapter/PDO/SqlPgsql.php
@@ -3,7 +3,6 @@
 namespace Phpmig\Adapter\PDO;
 
 use Phpmig\Migration\Migration,
-    Phpmig\Adapter\AdapterInterface,
     PDO;
 
 /**
@@ -12,33 +11,24 @@ use Phpmig\Migration\Migration,
  */
 class SqlPgsql extends Sql
 {
-    private $quote = "\"";
-    private $schemaName = "public";
+    private $quote;
+    private $schemaName;
 
     /**
-     * Constructor
-     *
-     * @param \PDO $connection
+     * @param \PDO   $connection
      * @param string $tableName
+     * @param string $schemaName
      */
     public function __construct(\PDO $connection, $tableName, $schemaName = 'public')
     {
         parent::__construct($connection, $tableName);
         $driver = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $this->quote = in_array($driver, array('mysql', 'pgsql')) ? '"' : '`';
+        $this->quote = in_array($driver, ['mysql', 'pgsql']) ? '"' : '`';
         $this->schemaName = $schemaName;
     }
 
-    private function quotedTableName()
-    {
-        $sql = "{$this->quote}{$this->schemaName}{$this->quote}.{$this->quote}{$this->tableName}{$this->quote}";
-        return $sql;
-    }
-
     /**
-     * Fetch all
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -47,10 +37,7 @@ class SqlPgsql extends Sql
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return self
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
@@ -61,10 +48,7 @@ class SqlPgsql extends Sql
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return self
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
@@ -74,11 +58,8 @@ class SqlPgsql extends Sql
         return $this;
     }
 
-
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -91,11 +72,8 @@ class SqlPgsql extends Sql
         return false;
     }
 
-
     /**
-     * Create Schema
-     *
-     * @return DBAL
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -120,5 +98,10 @@ class SqlPgsql extends Sql
         return $this;
     }
 
+    private function quotedTableName()
+    {
+        $sql = "{$this->quote}{$this->schemaName}{$this->quote}.{$this->quote}{$this->tableName}{$this->quote}";
+        return $sql;
+    }
 }
 

--- a/src/Phpmig/Adapter/Zend/Db.php
+++ b/src/Phpmig/Adapter/Zend/Db.php
@@ -45,12 +45,6 @@ class Db implements AdapterInterface
      */
     protected $adapter;
 
-    /**
-     *
-     *
-     * @param \Zend_Db_Adapter_Abstract $adapter
-     * @param \Zend_Config $configuration
-     */
     public function __construct(\Zend_Db_Adapter_Abstract $adapter, \Zend_Config $configuration)
     {
         $this->adapter = $adapter;
@@ -59,9 +53,7 @@ class Db implements AdapterInterface
     }
 
     /**
-     * Get all migrated version numbers
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -69,20 +61,18 @@ class Db implements AdapterInterface
         $select->from($this->tableName, 'version');
         $select->order('version ASC');
         $all = $this->adapter->fetchAll($select);
-        return array_map(function($v) {return $v['version'];}, $all);
+
+        return array_map(static function($v) {return $v['version'];}, $all);
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
-        $this->adapter->insert($this->tableName, array(
+        $this->adapter->insert($this->tableName, [
             'version' => $migration->getVersion(),
-        ));
+        ]);
 
         return $this;
     }
@@ -103,9 +93,7 @@ class Db implements AdapterInterface
     }
 
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
@@ -117,18 +105,11 @@ class Db implements AdapterInterface
             return false;
         }
 
-        if (is_array($schema) && !empty($schema)) {
-            return true;
-        }
-
-        return false;
+        return is_array($schema) && !empty($schema);
     }
 
     /**
-     * Create Schema
-     *
-     * @throws \InvalidArgumentException
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -163,5 +144,4 @@ class Db implements AdapterInterface
 
         return $this;
     }
-
 }

--- a/src/Phpmig/Adapter/Zend/DbAdapter.php
+++ b/src/Phpmig/Adapter/Zend/DbAdapter.php
@@ -37,32 +37,14 @@ class DbAdapter implements AdapterInterface
      */
     private $adapter;
 
-    /**
-     * @param Adapter $adapter
-     * @param string $tableName
-     */
-    public function __construct(Adapter $adapter, $tableName)
+    public function __construct(Adapter $adapter, string $tableName)
     {
         $this->adapter   = $adapter;
         $this->tableName = $tableName;
     }
 
     /**
-     * @return TableGateway
-     */
-    private function tableGateway()
-    {
-        if (!$this->tableGateway) {
-            $this->tableGateway = new TableGateway($this->tableName, $this->adapter);
-        }
-
-        return $this->tableGateway;
-    }
-
-    /**
-     * Get all migrated version numbers
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function fetchAll()
     {
@@ -71,16 +53,13 @@ class DbAdapter implements AdapterInterface
         })->toArray();
 
         // imitate fetchCol
-        return array_map(function ($item) {
+        return array_map(static function ($item) {
             return $item['version'];
         }, $result);
     }
 
     /**
-     * Up
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function up(Migration $migration)
     {
@@ -89,27 +68,24 @@ class DbAdapter implements AdapterInterface
     }
 
     /**
-     * Down
-     *
-     * @param Migration $migration
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function down(Migration $migration)
     {
         $this->tableGateway()->delete(['version' => $migration->getVersion()]);
+
         return $this;
     }
 
     /**
-     * Is the schema ready?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasSchema()
     {
         try {
             $metadata = new Metadata($this->adapter);
             $metadata->getTable($this->tableName);
+
             return true;
         } catch (\Exception $exception) {
             return false;
@@ -117,9 +93,7 @@ class DbAdapter implements AdapterInterface
     }
 
     /**
-     * Create Schema
-     *
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function createSchema()
     {
@@ -134,5 +108,17 @@ class DbAdapter implements AdapterInterface
         );
 
         return $this;
+    }
+
+    /**
+     * @return TableGateway
+     */
+    private function tableGateway()
+    {
+        if (!$this->tableGateway) {
+            $this->tableGateway = new TableGateway($this->tableName, $this->adapter);
+        }
+
+        return $this->tableGateway;
     }
 }

--- a/src/Phpmig/Console/Command/DownCommand.php
+++ b/src/Phpmig/Console/Command/DownCommand.php
@@ -7,8 +7,7 @@ namespace Phpmig\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputArgument,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Config\FileLocator;
+    Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This file is part of phpmig

--- a/src/Phpmig/Console/Command/InitCommand.php
+++ b/src/Phpmig/Console/Command/InitCommand.php
@@ -102,7 +102,7 @@ EOT
             return;
         }
 
-        if (!is_writeable(dirname($bootstrap))) {
+        if (!is_writable(dirname($bootstrap))) {
             throw new \RuntimeException(sprintf('The file "%s" is not writeable', $bootstrap));
         }
 

--- a/src/Phpmig/Console/Command/MigrateCommand.php
+++ b/src/Phpmig/Console/Command/MigrateCommand.php
@@ -7,8 +7,7 @@ namespace Phpmig\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputArgument,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Config\FileLocator;
+    Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This file is part of phpmig
@@ -70,13 +69,13 @@ EOT
 
         if (null !== $version) {
             if (0 != $version && !isset($migrations[$version])) {
-                return;
+                return 0;
             }
         } else {
             $versionNumbers = array_merge($versions, array_keys($migrations));
 
             if (empty($versionNumbers)) {
-                return;
+                return 0;
             }
 
             $version = max($versionNumbers);
@@ -84,7 +83,7 @@ EOT
 
         $direction = $version > $current ? 'up' : 'down';
 
-        if ($direction == 'down') {
+        if ($direction === 'down') {
             /**
              * Run downs first
              */

--- a/src/Phpmig/Console/Command/RedoCommand.php
+++ b/src/Phpmig/Console/Command/RedoCommand.php
@@ -7,8 +7,7 @@ namespace Phpmig\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputArgument,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Config\FileLocator;
+    Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This file is part of phpmig

--- a/src/Phpmig/Console/Command/RollbackCommand.php
+++ b/src/Phpmig/Console/Command/RollbackCommand.php
@@ -7,8 +7,7 @@ namespace Phpmig\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputArgument,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Config\FileLocator;
+    Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This file is part of phpmig

--- a/src/Phpmig/Console/Command/UpCommand.php
+++ b/src/Phpmig/Console/Command/UpCommand.php
@@ -7,8 +7,7 @@ namespace Phpmig\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Input\InputArgument,
-    Symfony\Component\Console\Output\OutputInterface,
-    Symfony\Component\Config\FileLocator;
+    Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This file is part of phpmig

--- a/src/Phpmig/Console/PhpmigApplication.php
+++ b/src/Phpmig/Console/PhpmigApplication.php
@@ -7,8 +7,6 @@ namespace Phpmig\Console;
 
 use Phpmig\Console\Command;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * This file is part of phpmig


### PR DESCRIPTION
Started with removing unused imports and fixing Symfony 5 compatibility (Commands should always return `int`), ended up fixing code style (missing typehints as we use PHP 7.1+, `@inheritDoc` instead of copy-pasted outdated phpdocs, short array-syntax, etc).