### PR TITLE
Avoid errors in AWS Redshift creating the schema

### DIFF
--- a/src/Phpmig/Adapter/PDO/SqlPgsql.php
+++ b/src/Phpmig/Adapter/PDO/SqlPgsql.php
@@ -88,7 +88,7 @@ class SqlPgsql extends Sql
             }
         }
 
-        $sql = "CREATE table {$this->quotedTableName()} (version %s NOT NULL, {$this->quote}migrate_date{$this->quote} timestamp(6) WITH TIME ZONE DEFAULT now())";
+        $sql = "CREATE table {$this->quotedTableName()} (version %s NOT NULL, {$this->quote}migrate_date{$this->quote} timestamp WITH TIME ZONE DEFAULT now())";
         $driver = $this->connection->getAttribute(PDO::ATTR_DRIVER_NAME);
         $sql = sprintf($sql, in_array($driver, array('mysql', 'pgsql')) ? 'VARCHAR(255)' : '');
 


### PR DESCRIPTION
When phpmig launches the query to create the schema, Redshift returns:

```
ERROR:  timestamp or timestamptz do not support precision.
```

Since indicating the precision is optional, I think it has more advantages not to indicate it, making this adapter compatible with more services in a simple way.