### PR TITLE
feat: php 8.4 support

### DIFF
--- a/src/Phpmig/Console/Command/CheckCommand.php
+++ b/src/Phpmig/Console/Command/CheckCommand.php
@@ -35,7 +35,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
         $versions = $this->getAdapter()->fetchAll();

--- a/src/Phpmig/Console/Command/DownCommand.php
+++ b/src/Phpmig/Console/Command/DownCommand.php
@@ -47,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phpmig/Console/Command/GenerateCommand.php
+++ b/src/Phpmig/Console/Command/GenerateCommand.php
@@ -50,7 +50,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phpmig/Console/Command/MigrateCommand.php
+++ b/src/Phpmig/Console/Command/MigrateCommand.php
@@ -48,7 +48,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phpmig/Console/Command/RedoCommand.php
+++ b/src/Phpmig/Console/Command/RedoCommand.php
@@ -47,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phpmig/Console/Command/RollbackCommand.php
+++ b/src/Phpmig/Console/Command/RollbackCommand.php
@@ -48,7 +48,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/src/Phpmig/Console/Command/StatusCommand.php
+++ b/src/Phpmig/Console/Command/StatusCommand.php
@@ -45,7 +45,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
         $output->writeln("");

--- a/src/Phpmig/Console/Command/UpCommand.php
+++ b/src/Phpmig/Console/Command/UpCommand.php
@@ -47,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bootstrap($input, $output);
 

--- a/tests/Phpmig/Api/PhpmigApplicationTest.php
+++ b/tests/Phpmig/Api/PhpmigApplicationTest.php
@@ -317,7 +317,7 @@ class PhpmigApplicationTest extends TestCase
         rmdir($dir);
     }
     
-    protected function createTestMigrations(array $migrations, array $class_names = null, $extends = "Migration")
+    protected function createTestMigrations(array $migrations, ?array $class_names = null, $extends = "Migration")
     {
         $class =<<< 'CODE'
 <?php


### PR DESCRIPTION
@davedevelopment Hi, I was trying to use phpmig with php 8.4 and got some errors so I fixed them.

for example: 

```
> phpmig migrate

Fatal error: Declaration of Phpmig\Console\Command\StatusCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in D:\path\to\vendor\davedevelopment\phpmig\src\Phpmig\Console\Command\StatusCommand.php on line 48
Script phpmig migrate handling the run:migrate event returned with error code 255
```